### PR TITLE
Wiringpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # The compiled executable
 /beep
+
+# The Makefile created by ./configure
+Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,9 +1,10 @@
-CC=gcc
-FLAGS=-Wall -O2
+CC=@CC@
+FLAGS=@FLAGS@
+LIBS=@LIBS@
 EXEC_NAME=beep
-INSTALL_DIR=/usr/bin
+INSTALL_DIR=@PREFIX@/bin
 MAN_FILE=beep.1.gz
-MAN_DIR=/usr/share/man/man1
+MAN_DIR=@PREFIX@/share/man/man1
 
 default : beep
 
@@ -11,7 +12,7 @@ clean :
 	rm ${EXEC_NAME}
 
 beep : beep.c
-	${CC} ${FLAGS} -o ${EXEC_NAME} beep.c
+	${CC} ${FLAGS} -o ${EXEC_NAME} beep.c ${LIBS}
 
 install :
 	cp ${EXEC_NAME} ${INSTALL_DIR}

--- a/README
+++ b/README
@@ -74,6 +74,14 @@ complex fix would be something like:
 
 and then add only beep-worthy users to the 'beep' group.
 
+Raspberry Pi
+------------
+
+beep can be used on a Raspberry Pi by attaching an old BIOS speaker or piezo
+buzzer to the PWM GPIO pin (BCM_GPIO 18). When not running as root, beep needs
+use a workaround that is significantly slower. Read the above section on how
+to run beep as suid root.
+
 Playing Songs
 -------------
 

--- a/configure
+++ b/configure
@@ -8,7 +8,7 @@ LIBS=
 if [[ -f /usr/include/wiringPi.h ]]; then
 	echo "Compiling with wiringPi support"
 	FLAGS+=" -DHAVE_WIRINGPI"
-	LIBS+="-lwiringPi"
+	LIBS+=" -lwiringPi"
 fi
 
 sed -e "s|@LIBS@|${LIBS}|" \

--- a/configure
+++ b/configure
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CC=gcc
+PREFIX=/usr
+FLAGS="-Wall -O2"
+LIBS=
+
+if [[ -f /usr/include/wiringPi.h ]]; then
+	echo "Compiling with wiringPi support"
+	FLAGS+=" -DHAVE_WIRINGPI"
+	LIBS+="-lwiringPi"
+fi
+
+sed -e "s|@LIBS@|${LIBS}|" \
+	-e "s|@FLAGS@|${FLAGS}|" \
+	-e "s|@PREFIX@|${PREFIX}|" \
+	-e "s|@CC@|${CC}|" \
+	Makefile.in > Makefile


### PR DESCRIPTION
This patch adds support for using `beep` on a Raspberry Pi, using an old BIOS speaker or piezo buzzer attached to its GPIO PWM pin.

When _not_ running as root, ugly `system()` calls are used to call the `gpio` binary included with `wiringPi`. Note that this is significantly slower, as the binary needs to be called 5 times for each tone! You might be better off running `beep` as `suid`.

The original Makefile has been replaced with a Makefile.in to accommodate the conditional compilation with `wiringPi` support.

Build with `./configure && make`.
