### PR TITLE
Makefile: respect DESTDIR in install destinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC=gcc
 FLAGS=-Wall -O2
 EXEC_NAME=beep
-INSTALL_DIR=/usr/bin
+INSTALL_DIR=${DESTDIR}/usr/bin
 MAN_FILE=beep.1.gz
-MAN_DIR=/usr/share/man/man1
+MAN_DIR=${DESTDIR}/usr/share/man/man1
 
 default : beep
 


### PR DESCRIPTION
See https://www.gnu.org/prep/standards/html_node/DESTDIR.html.

This allows build systems such as ptxdist to 'make install' to a
location other than /usr.

Signed-off-by: Bastian Krause <bst@pengutronix.de>