### PR TITLE
Check for supported events first, send SND_BELL as fallback

### DIFF
--- a/beep.c
+++ b/beep.c
@@ -106,17 +106,26 @@ void do_beep(int freq) {
       perror("ioctl");
     }
   } else {
-     /* BEEP_TYPE_EVDEV */
-     struct input_event e;
+    /* BEEP_TYPE_EVDEV */
+    struct input_event e;
+    unsigned long evbit = 0;
 
-     e.type = EV_SND;
-     e.code = SND_TONE;
-     e.value = freq;
+    e.type = EV_SND;
 
-     if(write(console_fd, &e, sizeof(struct input_event)) < 0) {
-       putchar('\a'); /* See above */
-       perror("write");
-     }
+    /* check supported events and act accordingly */
+    ioctl(console_fd, EVIOCGBIT(EV_SND, sizeof(evbit)), &evbit);
+    if(evbit & (1 << SND_TONE)) {
+      e.code = SND_TONE;
+      e.value = freq;
+    } else {
+      perror("no supported event type");
+      return;
+    }
+
+    if(write(console_fd, &e, sizeof(struct input_event)) < 0) {
+      putchar('\a'); /* See above */
+      perror("write");
+    }
   }
 }
 

--- a/beep.c
+++ b/beep.c
@@ -117,6 +117,9 @@ void do_beep(int freq) {
     if(evbit & (1 << SND_TONE)) {
       e.code = SND_TONE;
       e.value = freq;
+    } else if(evbit & (1 << SND_BELL)) {
+      e.code = SND_BELL;
+      e.value = (freq != 0);
     } else {
       perror("no supported event type");
       return;


### PR DESCRIPTION
The device might not support `SND_TONE` events, so check it and print an error if this event type is not supported.

The gpio-beeper driver does not support `SND_TONE`, but `SND_BELL`. So send that instead if `SND_TONE` is not supported.
